### PR TITLE
Capability to customize badge middle

### DIFF
--- a/lib/repo_small_badge/configuration.rb
+++ b/lib/repo_small_badge/configuration.rb
@@ -72,7 +72,15 @@ module RepoSmallBadge
     end
 
     def badge_middle
-      badge_width / 2
+      @config.fetch(:badge_middle, badge_width / 2).to_i
+    end
+
+    def title_middle
+      badge_middle / 2
+    end
+
+    def value_middle
+      badge_middle + (badge_width - badge_middle) / 2
     end
 
     def filename(suffix = '')

--- a/lib/repo_small_badge/image.rb
+++ b/lib/repo_small_badge/image.rb
@@ -69,7 +69,6 @@ module RepoSmallBadge
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
     def svg_title(title)
       element :g, fill: @config.title_color, 'text-anchor': 'middle',
                   'font-family': @config.title_font,
@@ -97,6 +96,5 @@ module RepoSmallBadge
       end
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/repo_small_badge/image.rb
+++ b/lib/repo_small_badge/image.rb
@@ -75,10 +75,10 @@ module RepoSmallBadge
                   'font-family': @config.title_font,
                   'font-size': @config.title_font_size do |_svg|
         element :text, @config.title(title),
-                x: @config.badge_middle / 2, y: @config.badge_height - 5,
+                x: @config.title_middle, y: @config.badge_height - 5,
                 fill: '#010101', 'fill-opacity': '0.3'
         element :text, @config.title(title),
-                x: @config.badge_middle / 2, y: @config.badge_height - 6
+                x: @config.title_middle, y: @config.badge_height - 6
       end
     end
 
@@ -88,11 +88,11 @@ module RepoSmallBadge
                   'font-family': @config.value_font,
                   'font-size': @config.value_font_size do |_svg|
         element :text, value,
-                x: @config.badge_middle / 2 + @config.badge_middle,
+                x: @config.value_middle,
                 y: @config.badge_height - 5,
                 fill: '#010101', 'fill-opacity': '0.3'
         element :text, value,
-                x: @config.badge_middle / 2 + @config.badge_middle,
+                x: @config.value_middle,
                 y: @config.badge_height - 6
       end
     end

--- a/lib/repo_small_badge/version.rb
+++ b/lib/repo_small_badge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RepoSmallBadge
-  VERSION = '0.2.7'
+  VERSION = '0.2.8'
 end

--- a/spec/repo_small_badge_spec.rb
+++ b/spec/repo_small_badge_spec.rb
@@ -41,6 +41,21 @@ describe RepoSmallBadge::Image do
           expect(subject.config_merge(badge_height: 10)[:badge_height]).to eq 10
         end
       end
+
+      context 'with different middle' do
+        subject do
+          described_class
+          .new(badge_width: 250, badge_middle: 190)
+        end
+
+        it 'will write a file' do
+          allow(File).to receive(:write)
+            .with('./badge_total.svg', rounded_svg_string(width: 250, middle: 190)).and_return(true)
+          expect(subject.badge('total', 'Total', '100%'))
+            .to be_truthy
+        end
+
+      end
     end
   end
 end

--- a/spec/repo_small_badge_spec.rb
+++ b/spec/repo_small_badge_spec.rb
@@ -45,16 +45,18 @@ describe RepoSmallBadge::Image do
       context 'with different middle' do
         subject do
           described_class
-          .new(badge_width: 250, badge_middle: 190)
+            .new(badge_width: 250, badge_middle: 190)
         end
+
+        let(:svg) { rounded_svg_string(width: 250, middle: 190) }
 
         it 'will write a file' do
           allow(File).to receive(:write)
-            .with('./badge_total.svg', rounded_svg_string(width: 250, middle: 190)).and_return(true)
+            .with('./badge_total.svg', svg)
+            .and_return(true)
           expect(subject.badge('total', 'Total', '100%'))
             .to be_truthy
         end
-
       end
     end
   end

--- a/spec/support/mocks.rb
+++ b/spec/support/mocks.rb
@@ -3,37 +3,38 @@
 module TestRepoSmallBadge
   # rubocop:disable Metrics/MethodLength,Metrics/LineLength,Metrics/ParameterLists
   def rounded_svg_string(title_color: '#fff', title_font: 'Verdana,sans-serif', title_font_size: 11,
-                         value_color: '#fff', value_font: 'Verdana,sans-serif', value_font_size: 11)
-    %(<svg contentScriptType="text/ecmascript" contentStyleType="text/css" preserveAspectRatio="xMidYMid meet" version="1.0" height="20" width="120"
+                         value_color: '#fff', value_font: 'Verdana,sans-serif', value_font_size: 11,
+                         width: 120, middle: 60)
+    %(<svg contentScriptType="text/ecmascript" contentStyleType="text/css" preserveAspectRatio="xMidYMid meet" version="1.0" height="20" width="#{width}"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
 
 
-<linearGradient id="smooth" x2="0" y2="120">
+<linearGradient id="smooth" x2="0" y2="#{width}">
 <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 <stop offset="1" stop-opacity=".1"/>
 </linearGradient>
 <clipPath id="round">
-<rect height="20" width="120" rx="3" fill="#fff"/>
+<rect height="20" width="#{width}" rx="3" fill="#fff"/>
 </clipPath>
 <g clip-path="url(#round)">
-<rect height="20" width="60" fill="#555"/>
-<rect x="60" height="20" width="60" fill="#4c1"/>
-<rect height="20" width="120" fill="url(#smooth)"/>
+<rect height="20" width="#{middle}" fill="#555"/>
+<rect x="#{middle}" height="20" width="#{middle}" fill="#4c1"/>
+<rect height="20" width="#{width}" fill="url(#smooth)"/>
 </g>
 <g fill="#{title_color}" text-anchor="middle" font-family="#{title_font}" font-size="#{title_font_size}">
-<text x="30" y="15" fill="#010101" fill-opacity="0.3">
+<text x="#{middle / 2}" y="15" fill="#010101" fill-opacity="0.3">
 Total
 </text>
-<text x="30" y="14">
+<text x="#{middle / 2}" y="14">
 Total
 </text>
 </g>
 <g fill="#{value_color}" text-anchor="middle" font-family="#{value_font}" font-size="#{value_font_size}">
-<text x="90" y="15" fill="#010101" fill-opacity="0.3">
+<text x="#{middle + (width - middle) / 2}" y="15" fill="#010101" fill-opacity="0.3">
 100%
 </text>
-<text x="90" y="14">
+<text x="#{middle + (width - middle) / 2}" y="14">
 100%
 </text>
 </g>


### PR DESCRIPTION
Currently this gem only supports a badge being split 50/50 between the title and the value.  I'd like the ability to customize the "middle" of the badge to accommodate large titles, but with small values.